### PR TITLE
Remove Vector{Any} from input data

### DIFF
--- a/IJKLM/IJKLM.jl
+++ b/IJKLM/IJKLM.jl
@@ -4,16 +4,20 @@ using DataFrames
 using BenchmarkTools
 using Gurobi
 
+function read_tuple_list(filename)
+    return [tuple(x...) for x in JSON.parsefile(filename)]
+end
+
 function read_fixed_data()
     N = open(JSON.parse, "IJKLM/data/data_N.json")
-    JKL = open(JSON.parse, "IJKLM/data/data_JKL.json")
-    KLM = open(JSON.parse, "IJKLM/data/data_KLM.json")
+    JKL = read_tuple_list("IJKLM/data/data_JKL.json")
+    KLM = read_tuple_list("IJKLM/data/data_KLM.json")
     return N, JKL, KLM
 end
 
 function read_variable_data(n)
     I = ["i$i" for i in 1:n]
-    IJK = open(JSON.parse, "IJKLM/data/data_IJK_$n.json")
+    IJK = read_tuple_list("IJKLM/data/data_IJK_$n.json")
     return I, IJK
 end
 

--- a/supply_chain/supply_chain.jl
+++ b/supply_chain/supply_chain.jl
@@ -4,21 +4,25 @@ using DataFrames
 using BenchmarkTools
 using Gurobi
 
+function read_tuple_list(filename)
+    return [tuple(x...) for x in JSON.parsefile(filename)]
+end
+
 function read_fixed_data()
     N = open(JSON.parse, "supply_chain/data/data_N.json")
     L = open(JSON.parse, "supply_chain/data/data_L.json")
     M = open(JSON.parse, "supply_chain/data/data_M.json")
-    JK = open(JSON.parse, "supply_chain/data/data_JK.json")
-    KL = open(JSON.parse, "supply_chain/data/data_KL.json")
-    LM = open(JSON.parse, "supply_chain/data/data_LM.json")
+    JK = read_tuple_list("supply_chain/data/data_JK.json")
+    KL = read_tuple_list("supply_chain/data/data_KL.json")
+    LM = read_tuple_list("supply_chain/data/data_LM.json")
     return N, L, M, JK, KL, LM
 end
 
 function read_variable_data(n)
     I = ["i$i" for i in 1:n]
-    IJ = open(JSON.parse, "supply_chain/data/data_IJ_$n.json")
-    IK = open(JSON.parse, "supply_chain/data/data_IK_$n.json")
-    d = open(JSON.parse, "supply_chain/data/data_D_$n.json")
+    IJ = read_tuple_list("supply_chain/data/data_IJ_$n.json")
+    IK = read_tuple_list("supply_chain/data/data_IK_$n.json")
+    d = read_tuple_list("supply_chain/data/data_D_$n.json")
     D = Dict()
     for x in d
         D[(x[1], x[2])] = x[3]


### PR DESCRIPTION
See discussion https://discourse.julialang.org/t/performance-julia-jump-vs-python-pyomo/92044/10

## IJKL

```
N, JKL, KLM = read_fixed_data()
I, IJK = read_variable_data(2200)
@time intuitive_jump(I, IJK, JKL, KLM, "True")
@time jump(I, IJK, JKL, KLM, "True")
```

Before
```
 46.410126 seconds (458.77 M allocations: 13.755 GiB, 5.66% gc time, 0.87% compilation time)
  5.847935 seconds (68.71 M allocations: 2.129 GiB, 14.43% gc time, 7.43% compilation time)
```
After
```
  2.581531 seconds (34.81 M allocations: 1.571 GiB, 13.12% gc time, 11.82% compilation time)
  1.974351 seconds (34.79 M allocations: 1.571 GiB, 17.32% gc time, 14.07% compilation time)
```

## Supply chain

```
N, L, M, JK, KL, LM = read_fixed_data()
I, IJ, IK, D = read_variable_data(2900)
@time intuitive_jump(I, L, M, IJ, JK, IK, KL, LM, D, "true")
@time jump(I, L, M, IJ, JK, IK, KL, LM, D, "true")
```

Before
```
  5.464284 seconds (58.09 M allocations: 1.819 GiB, 10.28% gc time, 23.07% compilation time)
  5.566194 seconds (53.90 M allocations: 1.639 GiB, 13.04% gc time, 16.28% compilation time)
```

After
```
  2.134637 seconds (16.16 M allocations: 645.383 MiB, 33.71% gc time, 34.56% compilation time)
  1.224279 seconds (12.96 M allocations: 511.826 MiB, 16.33% gc time, 44.46% compilation time)
```